### PR TITLE
Disk image upgrade

### DIFF
--- a/phenix/src/go/api/vm/vm.go
+++ b/phenix/src/go/api/vm/vm.go
@@ -1046,7 +1046,6 @@ func CommitToDisk(expName, vmName, out string, cb func(float64)) (string, error)
 
 }
 
-//-----------------------------------------------------------------------------------------------------------------
 
 func MemorySnapshot(expName, vmName, out string, cb func(string)) (string, error) {
 
@@ -1063,6 +1062,14 @@ func MemorySnapshot(expName, vmName, out string, cb func(string)) (string, error
 			return "", fmt.Errorf("getting new disk name for VM %s in experiment %s: %w", vmName, expName, err)
 		}
 		out = fmt.Sprintf("%s_%s__%s_memorySnapshot.elf", expName, vmName, out)
+	}
+
+	// Make all output file have a .elf extension
+	if filepath.Ext(out) != ".elf" {
+		if filepath.Ext(out) != "" {
+			out = strings.TrimSuffix(out, filepath.Ext(out)) 
+		}
+		out += ".elf"
 	}
 
 	base, err := getBaseImage(expName, vmName)
@@ -1101,7 +1108,7 @@ func MemorySnapshot(expName, vmName, out string, cb func(string)) (string, error
 	cmd.Command = fmt.Sprintf("vm qmp %s '%s'", vmName, qmp)
 
 	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
-		return "", fmt.Errorf("starting memory snapshot for VM %s: ERROR: %w -- cmd: '%s'", vmName, err, cmd)
+		return "", fmt.Errorf("starting memory snapshot for VM %s: ERROR: %w", vmName, err)
 		
 	}
 	
@@ -1116,18 +1123,31 @@ func MemorySnapshot(expName, vmName, out string, cb func(string)) (string, error
 	)
 	
 	for {
-		
+		//sleep before querying the vm to to prevent errors from start delays
+		time.Sleep(1 * time.Second)
 		res, err = mmcli.SingleResponse(mmcli.Run(cmd))
 		if err != nil {
-			cb("failed")
+			if cb != nil {
+				cb("failed")
+			}
 			return "",fmt.Errorf("getting memory dump status for VM %s: %w", vmName, err)
 		}
 		
 		json.Unmarshal([]byte(res), &v)	
 		
 		if len(v.Return.Status) == 0 {
-			cb("failed")
+			if cb != nil {
+				cb("failed")
+			}
 			return "",fmt.Errorf("no status available for %s: %s", vmName, v)
+		
+		}
+
+		if v.Return.Status == "failed" {
+			if cb != nil {
+				cb("failed")
+			}
+			return "failed",fmt.Errorf("failed to create disk image for %s: %s", vmName, v)
 		
 		}
 		
@@ -1139,11 +1159,6 @@ func MemorySnapshot(expName, vmName, out string, cb func(string)) (string, error
 			cb("completed")
 			break	
 		}
-		
-		time.Sleep(1 * time.Second)
-		
-		
-		
 		
 	}
 

--- a/phenix/src/go/cmd/vm.go
+++ b/phenix/src/go/cmd/vm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"path/filepath"
 
 	"phenix/api/vm"
 	"phenix/util"
@@ -499,6 +500,52 @@ func newVMCaptureCmd() *cobra.Command {
 	return cmd
 }
 
+func newVMDiskImageCmd() *cobra.Command {
+	desc := `Create disk image  for a VM
+	
+  Used to create the VM memory dump for a virtual machine in a running 
+  experiment; see command help for start and stop for additional arguments.`
+
+	cmd := &cobra.Command{
+		Use:   "diskimage <experiment name> <vm name> </path/to/out file> [flags]",
+		Short: "Create disk image for a VM",
+		Long:  desc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("Must provide an experiment name, VM name, and /path/to/out file")
+			}
+
+			var (
+				expName = args[0]
+				vmName  = args[1]
+				out		= args[2]
+			)
+
+			if _,err := os.Stat(filepath.Dir(out)); os.IsNotExist(err) {
+				return fmt.Errorf("%s is an invalid filepath", out)
+			}
+
+			cb := func(s string) {}
+			if res, err := vm.MemorySnapshot(expName, vmName, out, cb); err != nil{
+				if res != "failed" {
+					err := util.HumanizeError(err, "Unable to create disk image for the "+vmName+" VM")
+					return err.Humanized()
+				}else {	
+					err := util.HumanizeError(err, "Failed to create disk image for the "+vmName+" VM")
+					return err.Humanized()
+				}	
+			}
+
+			fmt.Printf("Disk image was created for the %s VM in the %s experiment\n", vmName, expName)
+			
+			return nil
+
+		},
+	}
+
+	return cmd
+}
+
 func init() {
 	vmCmd := newVMCmd()
 
@@ -513,6 +560,7 @@ func init() {
 	vmCmd.AddCommand(newVMSetCmd())
 	vmCmd.AddCommand(newVMNetCmd())
 	vmCmd.AddCommand(newVMCaptureCmd())
+	vmCmd.AddCommand(newVMDiskImageCmd())
 
 	rootCmd.AddCommand(vmCmd)
 }

--- a/phenix/src/go/cmd/vm.go
+++ b/phenix/src/go/cmd/vm.go
@@ -500,15 +500,15 @@ func newVMCaptureCmd() *cobra.Command {
 	return cmd
 }
 
-func newVMDiskImageCmd() *cobra.Command {
+func newVMMemoryDumpCmd() *cobra.Command {
 	desc := `Create disk image  for a VM
 	
   Used to create the VM memory dump for a virtual machine in a running 
   experiment; see command help for start and stop for additional arguments.`
 
 	cmd := &cobra.Command{
-		Use:   "diskimage <experiment name> <vm name> </path/to/out file> [flags]",
-		Short: "Create disk image for a VM",
+		Use:   "memorydump <experiment name> <vm name> </path/to/out file> [flags]",
+		Short: "Create a memory dump for a VM",
 		Long:  desc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
@@ -528,15 +528,15 @@ func newVMDiskImageCmd() *cobra.Command {
 			cb := func(s string) {}
 			if res, err := vm.MemorySnapshot(expName, vmName, out, cb); err != nil{
 				if res != "failed" {
-					err := util.HumanizeError(err, "Unable to create disk image for the "+vmName+" VM")
+					err := util.HumanizeError(err, "Unable to create a memory dump for the "+vmName+" VM")
 					return err.Humanized()
 				}else {	
-					err := util.HumanizeError(err, "Failed to create disk image for the "+vmName+" VM")
+					err := util.HumanizeError(err, "Failed to create a memory dump for the "+vmName+" VM")
 					return err.Humanized()
 				}	
 			}
 
-			fmt.Printf("Disk image was created for the %s VM in the %s experiment\n", vmName, expName)
+			fmt.Printf("Memory dump was created for the %s VM in the %s experiment\n", vmName, expName)
 			
 			return nil
 
@@ -560,7 +560,7 @@ func init() {
 	vmCmd.AddCommand(newVMSetCmd())
 	vmCmd.AddCommand(newVMNetCmd())
 	vmCmd.AddCommand(newVMCaptureCmd())
-	vmCmd.AddCommand(newVMDiskImageCmd())
+	vmCmd.AddCommand(newVMMemoryDumpCmd())
 
 	rootCmd.AddCommand(vmCmd)
 }

--- a/phenix/src/js/src/components/RunningExperiment.vue
+++ b/phenix/src/js/src/components/RunningExperiment.vue
@@ -42,7 +42,7 @@
         </div>
         <div v-if="experimentUser() && !showModifyStateBar && expModal.vm.running">
              &nbsp; 
-          <b-tooltip  label="create a disk image" type="is-light">
+          <b-tooltip  label="Dump memory" type="is-light">
             <b-button class="button is-light" icon-left="database" @click="memoryDump(expModal.vm.name)">
              </b-button>
           </b-tooltip>
@@ -255,7 +255,7 @@
     <b-modal :active.sync="memoryDumpModal.active" has-modal-card :on-cancel="resetMemoryDumpModal" ref="memoryDump">
       <div  class="modal-card" style="width:auto">
         <header class="modal-card-head">
-          <p  class="modal-card-title">Create a Disk Image</p>
+          <p  class="modal-card-title">Dump memory</p>
         </header>
         <section class="modal-card-body">
          <div v-if="memoryDumpModal.vm.length > 0">
@@ -263,7 +263,7 @@
                  <div class="level-item">             
                   <font color="#202020">
                     <hr v-if="parseInt(index) > 0" style="color:#595959;background-color:#595959">
-                        Create memory capture of the {{ vmI.name }} VM with filename:                 
+                        Create a memory dump for the {{ vmI.name }} VM with filename:                 
                         <br><br>
                         <b-field :type="vmI.nameErrType" :message="vmI.nameErrMsg" autofocus>
                           <b-input  type="text" v-model="vmI.filename"   focus></b-input>
@@ -320,7 +320,7 @@
             </div>
           <div  v-if="experimentUser() && !showModifyStateBar">
               &nbsp;  
-              <b-tooltip  label="create a disk image" type="is-light">
+              <b-tooltip  label="Dump memory" type="is-light">
                 <b-button class="button is-light" icon-left="database" @click="processMultiVmAction(vmActions.createMemorySnapshot)">
                 </b-button>
               </b-tooltip>
@@ -936,7 +936,7 @@
                       let disk  = msg.result.disk;
                   
                       this.$buefy.toast.open({
-                        message: 'The memory snapshot with name ' + disk + ' for the ' + vm[ 1 ] + ' VM was successfully created.',
+                        message: 'A aemory dump was created with name ' + disk + ' for the ' + vm[ 1 ] + ' VM was successfully created.',
                         type: 'is-success',
                         duration: 4000
                       });
@@ -961,7 +961,7 @@
                     let disk = msg.result.disk;
                 
                     this.$buefy.toast.open({
-                      message:  'A memory snapshot with name ' + disk + ' for the ' + vm[ 1 ] + ' VM is being created.',
+                      message:  'A memory dump with name ' + disk + ' for the ' + vm[ 1 ] + ' VM is being created.',
                       type: 'is-warning',
                       duration: 4000
                     });
@@ -1516,7 +1516,7 @@
           
           this.$http.post(url,body,{ timeout: 0 }).then(
             response => {
-               console.log('memory snapshot for vm ' + name + ' failed with ' + response.status);
+               console.log('memory dump for vm ' + name + ' failed with ' + response.status);
             });
         });
       },

--- a/phenix/src/js/src/components/RunningExperiment.vue
+++ b/phenix/src/js/src/components/RunningExperiment.vue
@@ -42,7 +42,7 @@
         </div>
         <div v-if="experimentUser() && !showModifyStateBar && expModal.vm.running">
              &nbsp; 
-          <b-tooltip  label="create memory snapshot" type="is-light">
+          <b-tooltip  label="create a disk image" type="is-light">
             <b-button class="button is-light" icon-left="database" @click="memoryDump(expModal.vm.name)">
              </b-button>
           </b-tooltip>
@@ -255,7 +255,7 @@
     <b-modal :active.sync="memoryDumpModal.active" has-modal-card :on-cancel="resetMemoryDumpModal" ref="memoryDump">
       <div  class="modal-card" style="width:auto">
         <header class="modal-card-head">
-          <p  class="modal-card-title">Create a Memory Snapshot</p>
+          <p  class="modal-card-title">Create a Disk Image</p>
         </header>
         <section class="modal-card-body">
          <div v-if="memoryDumpModal.vm.length > 0">
@@ -320,7 +320,7 @@
             </div>
           <div  v-if="experimentUser() && !showModifyStateBar">
               &nbsp;  
-              <b-tooltip  label="create memory snapshot" type="is-light">
+              <b-tooltip  label="create a disk image" type="is-light">
                 <b-button class="button is-light" icon-left="database" @click="processMultiVmAction(vmActions.createMemorySnapshot)">
                 </b-button>
               </b-tooltip>
@@ -2323,6 +2323,7 @@
             this.memoryDumpModal.vm[i].nameErrType = '';
             this.memoryDumpModal.vm[i].nameErrMsg = '';
         }
+
         return true;
       },
 

--- a/phenix/src/js/yarn.lock
+++ b/phenix/src/js/yarn.lock
@@ -674,24 +674,29 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.26":
-  version "0.2.26"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.26.tgz#6e0b13a752676036f8196f8a1500d53a27b4adc1"
-  integrity sha512-CcM/fIFwZlRdiWG/25xE/wHbtyUuCtqoCTrr6BsWw7hH072fR++n4L56KPydAr3ANgMJMjT8v83ZFIsDc7kE+A==
+"@fortawesome/fontawesome-common-types@^0.2.34":
+  version "0.2.34"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz#0a8c348bb23b7b760030f5b1d912e582be4ec915"
+  integrity sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA==
 
-"@fortawesome/fontawesome-svg-core@^1.2.18":
-  version "1.2.26"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.26.tgz#671569271d6b532cdea5e3deb8ff16f8b7ac251d"
-  integrity sha512-3Dfd/v2IztP1TxKOxZiB5+4kaOZK9mNy0KU1vVK7nFlPWz3gzxrCWB+AloQhQUoJ8HhGqbzjliK89Vl7PExGbw==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.26"
+"@fortawesome/fontawesome-free@^5.15.2":
+  version "5.15.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.2.tgz#218cd7276ab4f9ab57cc3d2efa2697e6a579f25d"
+  integrity sha512-7l/AX41m609L/EXI9EKH3Vs3v0iA8tKlIOGtw+kgcoanI7p+e4I4GYLqW3UXWiTnjSFymKSmTTPKYrivzbxxqA==
 
-"@fortawesome/free-solid-svg-icons@^5.8.2":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.0.tgz#8decac5844e60453cc0c7c51437d1461df053a35"
-  integrity sha512-CnpsWs6GhTs9ekNB3d8rcO5HYqRkXbYKf2YNiAlTWbj5eVlPqsd/XH1F9If8jkcR1aegryAbln/qYeKVZzpM0g==
+"@fortawesome/fontawesome-svg-core@^1.2.34":
+  version "1.2.34"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.34.tgz#1d1a7c92537cbc2b8a83eef6b6d824b4b5b46b26"
+  integrity sha512-0KNN0nc5eIzaJxlv43QcDmTkDY1CqeN6J7OCGSs+fwGPdtv0yOQqRjieopBCmw+yd7uD3N2HeNL3Zm5isDleLg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.26"
+    "@fortawesome/fontawesome-common-types" "^0.2.34"
+
+"@fortawesome/free-solid-svg-icons@^5.15.2":
+  version "5.15.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.2.tgz#25bb035de57cf85aee8072965732368ccc8e8943"
+  integrity sha512-ZfCU+QjaFsdNZmOGmfqEWhzI3JOe37x5dF4kz9GeXvKn/sTxhqMtZ7mh3lBf76SvcYY5/GKFuyG7p1r4iWMQqw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.34"
 
 "@fortawesome/vue-fontawesome@^0.1.6":
   version "0.1.9"


### PR DESCRIPTION
changed labels from create memory snapshot to dump memory
moved sleep to the start of the memory dump query to avoid error from start delays
Added check for extension in memorySnapshot function, adds .elf extension to all disk image output files
Added cli interface for dump-guest-memory vm command called: diskimage